### PR TITLE
Add better logging to diagnose problems faster

### DIFF
--- a/telstar/__init__.py
+++ b/telstar/__init__.py
@@ -1,9 +1,13 @@
 """
 Telstar is a package to write producer and consumers groups against redis streams.
 """
+__version__ = "0.1.2"
+
+import logging
+
 from .com import StagedMessage
 
-__version__ = "0.1.1"
+log = logging.getLogger(__package__).addHandler(logging.NullHandler())
 
 
 def stage(topic, data):

--- a/telstar/consumer.py
+++ b/telstar/consumer.py
@@ -134,6 +134,7 @@ class MultiConsumer(object):
                 next_after_seen = self.increment(last_seen[stream_name])
                 last_seen[stream_name] = min([before_earliest, next_after_seen])
         # Read all message for the past up until now.
+        log.info(f"Read messages from the past on Stream:{last_seen} as Consumer: {self.consumer_name} in Group: {self.group_name}")
         self.catchup(last_seen)
 
     # This is the main loop where we start from the history
@@ -193,7 +194,7 @@ class MultiConsumer(object):
             log.debug(f"Message: {msg.msg_uuid} was already processed in Group: {self.group_name} - {stream_msg_id}")
             return done()
 
-        log.debug(f"Processing message: {msg.msg_uuid} - {stream_msg_id}")
+        log.info(f"Processing message: {msg.msg_uuid} - {stream_msg_id}")
         self.processors[stream_name.decode("ascii")](self, msg, done)
 
     # Process all message from `start`

--- a/telstar/producer.py
+++ b/telstar/producer.py
@@ -52,8 +52,9 @@ class StagedProducer(Producer):
             def done():
                 ids = list(map(lambda l: l.id, qs))
                 if ids:
-                    log.debug(f"Attempting to mark {len(msgs)} messages as being sent")
-                    StagedMessage.update(sent=True).where(StagedMessage.id in ids).execute()
+                    log.debug(f"Attempting to mark {len(ids)} messages as being sent")
+                    result = StagedMessage.update(sent=True).where(StagedMessage.id in ids).execute()
+                    log.debug(f"Result was: {result}")
                 sleep(self.wait)
 
             return msgs, done

--- a/telstar/tests/test_consumer.py
+++ b/telstar/tests/test_consumer.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import random
 import sys
@@ -6,12 +7,17 @@ from time import sleep
 import peewee
 import redis
 from playhouse.db_url import connect
+
 from telstar.com import Message
 from telstar.consumer import MultiConsumer
 
 link = redis.from_url(os.environ["REDIS"])
 db = connect(os.environ["DATABASE"])
 db.connect()
+
+logger = logging.getLogger('telstar')
+logger.addHandler(logging.StreamHandler())
+logger.setLevel(logging.DEBUG)
 
 
 class Test(peewee.Model):

--- a/telstar/tests/test_producer.py
+++ b/telstar/tests/test_producer.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import random
 import sys
@@ -9,8 +10,17 @@ from typing import Callable, List, Tuple
 import peewee
 import redis
 from playhouse.db_url import connect
+
 from telstar.com import Message
 from telstar.producer import Producer
+
+link = redis.from_url(os.environ["REDIS"])
+db = connect(os.environ["DATABASE"])
+db.connect()
+
+logger = logging.getLogger('telstar')
+logger.addHandler(logging.StreamHandler())
+logger.setLevel(logging.DEBUG)
 
 
 class JSONField(peewee.TextField):
@@ -20,11 +30,6 @@ class JSONField(peewee.TextField):
     def python_value(self, value):
         if value is not None:
             return json.loads(value)
-
-
-link = redis.from_url(os.environ["REDIS"])
-db = connect(os.environ["DATABASE"])
-db.connect()
 
 
 class Events(peewee.Model):

--- a/telstar/tests/test_telstar.sh
+++ b/telstar/tests/test_telstar.sh
@@ -19,6 +19,7 @@ export REDIS="${REDIS:-redis://localhost:6379/10}"
 export DATABASE="${DATABASE:-mysql://root:root@127.0.0.1:3306/test}"
 
 export PYTHONPATH="${PYTHONPATH}:${SCRIPTPATH}../}"
+export PYTHONUNBUFFERED=True
 
 readonly SCRIPTPATH="$(
     cd "$(dirname "$0")"
@@ -30,6 +31,7 @@ function kill_childs_and_exit() {
     echo "..."
     pkill -P $$
     echo "ok, bye"
+    exit 1
 }
 
 # TRAP CTRL-C and kill all childs


### PR DESCRIPTION
With this release, we get logging messages that are easy to configure from a users perspective. 

```python
import logging
logger = logging.getLogger('telstar')
logger.addHandler(logging.StreamHandler())
logger.setLevel(logging.DEBUG)
```

Will result in the following logs:
```
Message: 0e598e9a-8f86-4e31-ad5f-45d5f525e6da was already processed in Group: validation - b'1562694472238-3'
Acknowledging message 0e598e9a-8f86-4e31-ad5f-45d5f525e6da - b'1562694472238-3'
Read messages from the past on Stream:{'telstar:stream:mystream': b'1562694472238-3', 'telstar:stream:mystream2': b'1562694460751-0'} as Consumer: 4 in Group: validation
Awaiting new messages on Stream:dict_keys(['telstar:stream:mystream', 'telstar:stream:mystream2']) as Consumer: 4 in Group: validation
```