### PR TITLE
Add instruments that allows you to migrate consumer code.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,9 +30,12 @@ jobs:
       - run:
           command: |
             source venv/bin/activate
-            pytest --ignore=telstar/
+            pytest -m 'not integration' --ignore=telstar/
 
-  simulate-telstar:
+  integration-test:
+    parameters:
+      command:
+        type: string
     working_directory: ~/telstar
     docker:
       - image: circleci/python:3.6
@@ -64,36 +67,39 @@ jobs:
             popd
             source venv/bin/activate
             dockerize -wait tcp://localhost:3306 -timeout 1m
-            ./telstar/tests/test_telstar.sh
-
+            << parameters.command >>
 
   release:
     docker:
       - image: circleci/python:3.6
     working_directory: ~/telstar
     steps:
-    - checkout
-    - restore_cache:
-        key: v1-deps-{{ .Branch }}-{{ checksum "requirements.txt" }}
-    - run:
-        command: |
-          source venv/bin/activate
-          flit build
-          flit publish
-
-
+      - checkout
+      - restore_cache:
+          key: v1-deps-{{ .Branch }}-{{ checksum "requirements.txt" }}
+      - run:
+          command: |
+            source venv/bin/activate
+            flit build
+            flit publish
 
 workflows:
-  version: "2.1"
   build_and_test:
     jobs:
       - build
-
       - test:
           requires:
             - build
 
-      - simulate-telstar:
+      - integration-test:
+          name: integration-resiliency
+          command: ./telstar/tests/test_telstar.sh
+          requires:
+            - build
+
+      - integration-test:
+          name: integration-pytest
+          command: pytest -m 'integration' --ignore=telstar/
           requires:
             - build
 
@@ -104,4 +110,5 @@ workflows:
                 - master
           requires:
             - test
-            - simulate-telstar
+            - integration-pytest
+            - integration-resiliency

--- a/telstar/__init__.py
+++ b/telstar/__init__.py
@@ -1,7 +1,7 @@
 """
 Telstar is a package to write producer and consumers groups against redis streams.
 """
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 
 import logging
 

--- a/telstar/consumer.py
+++ b/telstar/consumer.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import uuid
+import time
 from functools import partial
 
 import redis
@@ -94,6 +95,7 @@ class MultiConsumer(object):
         #  'consumers': [{'name': b'cg-userSignUp.1', 'pending': 10}]}
         # Nothing to do
         if pending_info["pending"] == 0:
+            log.debug(f"Found no pending messages in Stream: {stream_name} in Group: {self.group_name}")
             return
         # Get all messages ids within that range and select the ones we want to claim and claim them
         # But only if they are pending for more than 20secs.
@@ -134,7 +136,7 @@ class MultiConsumer(object):
                 next_after_seen = self.increment(last_seen[stream_name])
                 last_seen[stream_name] = min([before_earliest, next_after_seen])
         # Read all message for the past up until now.
-        log.info(f"Read messages from the past on Stream:{last_seen} as Consumer: {self.consumer_name} in Group: {self.group_name}")
+        log.info(f"Read messages from the past on Stream: {last_seen} as Consumer: {self.consumer_name} in Group: {self.group_name}")
         self.catchup(last_seen)
 
     # This is the main loop where we start from the history
@@ -149,7 +151,7 @@ class MultiConsumer(object):
         self.transfer_and_process_stream_history(self.streams)
         # With our history processes we can now start waiting for new message to arrive `>`
         config = {k: ">" for k in self.streams}
-        log.info(f"Awaiting new messages on Stream:{self.streams} as Consumer: {self.consumer_name} in Group: {self.group_name}")
+        log.info(f"Awaiting new messages on Stream: {self.streams} as Consumer: {self.consumer_name} in Group: {self.group_name}")
         self.read(config, block=self.block)
 
     def get_last_seen_id(self, stream_name: str):
@@ -221,3 +223,35 @@ class MultiConsumer(object):
 class Consumer(MultiConsumer):
     def __init__(self, link, group_name, consumer_name, stream_name, processor_fn):
         super().__init__(link, group_name, consumer_name, {stream_name: processor_fn})
+
+
+class MultiConsumeOnce(MultiConsumer):
+    # This lets you write code that is executed once against an entire stream
+    # TODO: What would be really cool is to have this sort of like migrations
+    #       where `telstar` itself has cli commands to add and run files containing
+    #       `MultiConsumeOnce` code.
+    def __init__(self, link: redis.Redis, group_name: str, config: dict):
+        super().__init__(link, group_name, "once-consumer", config, 2000, 20000)
+
+    def _applied_key(self):
+        return f"telstar:once:{self.group_name}"
+
+    def is_applied(self):
+        key = self._applied_key()
+        return bool(self.link.get(key))
+
+    def mark_as_applied(self):
+        key = self._applied_key()
+        return self.link.set(key, int(time.time()))
+
+    def run(self):
+        if self.is_applied():
+            log.info(f"Not running Group: {self.group_name} for Streams: {self.streams} as it already ran")
+            return
+        # Reading a stream from ">" has a special meaning, it instructs redis to send all messages to the group
+        # Which does two things first it puts them all into the pending list of that consumer inside the group
+        # and also delivers them to the client.
+        streams = {s: ">" for s in self.streams}
+        num_processed = self.read(streams, 0)
+        self.mark_as_applied()
+        return num_processed


### PR DESCRIPTION
### Updating Consumer Code
Imagine a scenario where you had a consumer listen on a specific event like this:
```python
def consumer(c, m, done):
    save(m.data)
    done()

MultiConsumer(..., group_name="grp.v1", {"mystream": consumer})
```
#### Adding new capabilities
Our function should now be extended *and* consume all past message as well. So basically
```python
# This is not going to work
def consumer(c, m, done):
    save(m.data)
    report(m.data)
    done()
```
#### What you need to do - `ThreadedMultiConsumer`
You have two options now use `MultiConsumeOnce` to write code that consumes all messages and does *only* `report` which is *not* and recommended as it seems unpure. Why unpure? Redis streams redeliver all messages to new groups when they are first created and setting the starting id to `0`  which allows us to just create a consumer group `grp.v2` To make this even easier to handle this PR introduces the `ThreadedMultiConsumer` to allow you to just do that. 

```python
def consumerv1(c, m, done):
    save(m.data)
    done()

def consumerv2(c, m, done):
    report(m.data)
    done()

ThreadedMultiConsumer(..., config={
    "grp.v1":{"mystream": consumerv1}
    "grp.v2":{"mystream": consumerv2}
})

```
Another property that arises is the fact that `grp.v1` and `grp.v2` are guaranteed to have the same message which means that after some time you can consolidate the code back to:
```python
def consumer(c, m, done):
    save(m.data)
    report(m.data)
    done()

ThreadedMultiConsumer(..., config={
    "grp.v2":{"mystream": consumer}
})

```
#### `MultiConsumeOnce` 
The `MultiConsumeOnce` how might still be useful as it allows you to write idempotent stream processors that only execute once for all given message to the point in time where the code is executed the first time. 

```python
link = redis.from_url("redis://")
def callback(consumer, message, done):
    print(m.__dict__)
    done()

m = MultiConsumeOnce(link, "updateOnce", {
    "userSignedIn": callback
})
m.run()
```