### PR TITLE
Add a better API and gurantees around messages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,6 @@ jobs:
             popd
             source venv/bin/activate
             dockerize -wait tcp://localhost:3306 -timeout 1m
-            flit install 
             << parameters.command >>
 
   release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,6 @@ jobs:
           key: v1-deps-{{ .Branch }}-{{ checksum "requirements.txt" }}
       - run:
           command: |
-            sudo apt-get install mysql-client
             pushd `pwd`
             cd /tmp
             wget http://download.redis.io/redis-stable.tar.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,7 @@ jobs:
             popd
             source venv/bin/activate
             dockerize -wait tcp://localhost:3306 -timeout 1m
+            flit install 
             << parameters.command >>
 
   release:

--- a/README.md
+++ b/README.md
@@ -114,10 +114,10 @@ REDIS=redis:// python consumer.py
 ```
 You should see output like the following
 ```bash
-{'stream': 'telstar:stream:mytopic', 'msg_uuid': b'64357230-8ff3-4eb9-8c06-757a42e961e2', 'data': {'key': 'value'}}
-{'stream': 'telstar:stream:mytopic', 'msg_uuid': b'a2443ae2-549e-49ab-9256-3f13575ba6ae', 'data': {'key': 'value'}}
-{'stream': 'telstar:stream:mytopic', 'msg_uuid': b'1c1d9f8c-e37b-43be-bab2-45caa10f233d', 'data': {'key': 'value'}}
-{'stream': 'telstar:stream:mytopic', 'msg_uuid': b'5da942ab-4aec-4a7f-bd93-a97168a8d3ad', 'data': {'key': 'value'}}
+{'stream': 'mytopic', 'msg_uuid': b'64357230-8ff3-4eb9-8c06-757a42e961e2', 'data': {'key': 'value'}}
+{'stream': 'mytopic', 'msg_uuid': b'a2443ae2-549e-49ab-9256-3f13575ba6ae', 'data': {'key': 'value'}}
+{'stream': 'mytopic', 'msg_uuid': b'1c1d9f8c-e37b-43be-bab2-45caa10f233d', 'data': {'key': 'value'}}
+{'stream': 'mytopic', 'msg_uuid': b'5da942ab-4aec-4a7f-bd93-a97168a8d3ad', 'data': {'key': 'value'}}
 ```
 Until the stream is exhausted.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ author-email = "kai.koenig@bitspark.de"
 home-page = "https://bitspark.de"
 requires = [
     "redis",
-    "peewee"
+    "peewee",
+    "marshmallow==3.0.0rc8"
 ]
 classifiers = ["License :: OSI Approved :: MIT License"]
 requires-python = ">=3.6"

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ urllib3==1.25.3
 wcwidth==0.1.7
 wrapt==1.11.2
 zipp==0.5.1
+marshmallow==3.0.0rc8

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ idna==2.8
 importlib-metadata==0.18
 isort==4.3.20
 lazy-object-proxy==1.4.1
+marshmallow==3.0.0rc8
 mccabe==0.6.1
 more-itertools==7.0.0
 packaging==19.0
@@ -19,6 +20,8 @@ pylint==2.3.1
 PyMySQL==0.9.3
 pyparsing==2.4.0
 pytest==4.6.3
+pytest-mock==1.10.4
+pytest-pudb==0.7.0
 pytoml==0.1.20
 redis==3.2.1
 requests==2.22.0
@@ -28,4 +31,3 @@ urllib3==1.25.3
 wcwidth==0.1.7
 wrapt==1.11.2
 zipp==0.5.1
-marshmallow==3.0.0rc8

--- a/telstar/__init__.py
+++ b/telstar/__init__.py
@@ -13,7 +13,8 @@ from marshmallow import Schema, ValidationError
 from .com import Message, StagedMessage
 from .consumer import MultiConsumer, ThreadedMultiConsumer
 
-log = logging.getLogger(__package__).addHandler(logging.NullHandler())
+logging.getLogger(__package__).addHandler(logging.NullHandler())
+log = logging.getLogger(__package__)
 
 
 def stage(topic, data):

--- a/telstar/__init__.py
+++ b/telstar/__init__.py
@@ -61,6 +61,7 @@ class app:
                         fn(msg) if fullmessage else fn(msg.data)
                         done()
                     except ValidationError as err:
+                        log.error("Unable to validate message", exc_info=True)
                         if acknowledge_invalid:
                             done()
                         if strict:

--- a/telstar/__init__.py
+++ b/telstar/__init__.py
@@ -25,17 +25,21 @@ def staged():
 
 
 class app:
-    def __init__(self, link: redis.Redis, consumer_name: str, consumer_cls: MultiConsumer = ThreadedMultiConsumer):
+    def __init__(self, link: redis.Redis, consumer_name: str, consumer_cls: MultiConsumer = ThreadedMultiConsumer, **kwargs):
         self.link: redis = link
         self.config: dict = {}
         self.consumer_name: str = consumer_name
         self.consumer_cls: MultiConsumer = consumer_cls
+        self.kwargs = kwargs
+
+    def get_consumer(self):
+        return self.consumer_cls(self.link, self.consumer_name, self.config, **self.kwargs)
 
     def start(self):
-        self.consumer_cls(self.link, self.consumer_name, self.config).run()
+        self.get_consumer().run()
 
     def run_once(self):
-        self.consumer_cls(self.link, self.consumer_name, self.config).run_once()
+        self.get_consumer().run_once()
 
     def consumer(self, group: str, stream: str, schema: Schema, strict=True, acknowledge_invalid=False):
         def decorator(fn):

--- a/telstar/__init__.py
+++ b/telstar/__init__.py
@@ -37,7 +37,7 @@ class app:
     def run_once(self):
         self.consumer_cls(self.link, self.consumer_name, self.config).run_once()
 
-    def consumer(self, group: str, stream: str, schema: Schema, strict=False, acknowledge_invalid=True):
+    def consumer(self, group: str, stream: str, schema: Schema, strict=True, acknowledge_invalid=False):
         def decorator(fn):
             @wraps(fn)
             def actual_consumer(consumer: MultiConsumer, msg: Message, done: callable):
@@ -46,10 +46,10 @@ class app:
                     fn(data)
                     done()
                 except ValidationError as err:
-                    if strict:
-                        raise err
                     if acknowledge_invalid:
                         done()
+                    if strict:
+                        raise err
 
             if group in self.config:
                 self.config[group][stream] = actual_consumer

--- a/telstar/__init__.py
+++ b/telstar/__init__.py
@@ -1,11 +1,16 @@
 """
 Telstar is a package to write producer and consumers groups against redis streams.
 """
-__version__ = "0.1.6"
+__version__ = "0.2.0"
 
 import logging
+from functools import wraps
 
-from .com import StagedMessage
+import redis
+from marshmallow import Schema, ValidationError
+
+from .com import Message, StagedMessage
+from .consumer import MultiConsumer, ThreadedMultiConsumer
 
 log = logging.getLogger(__package__).addHandler(logging.NullHandler())
 
@@ -17,3 +22,38 @@ def stage(topic, data):
 
 def staged():
     return [e.to_msg() for e in StagedMessage.unsent()]
+
+
+class app:
+    def __init__(self, link: redis.Redis, consumer_name: str, consumer_cls: MultiConsumer = ThreadedMultiConsumer):
+        self.link: redis = link
+        self.config: dict = {}
+        self.consumer_name: str = consumer_name
+        self.consumer_cls: MultiConsumer = consumer_cls
+
+    def start(self):
+        self.consumer_cls(self.link, self.consumer_name, self.config).run()
+
+    def run_once(self):
+        self.consumer_cls(self.link, self.consumer_name, self.config).run_once()
+
+    def consumer(self, group: str, stream: str, schema: Schema, strict=False, acknowledge_invalid=True):
+        def decorator(fn):
+            @wraps(fn)
+            def actual_consumer(consumer: MultiConsumer, msg: Message, done: callable):
+                try:
+                    data = schema().load(msg.data)
+                    fn(data)
+                    done()
+                except ValidationError as err:
+                    if strict:
+                        raise err
+                    if acknowledge_invalid:
+                        done()
+
+            if group in self.config:
+                self.config[group][stream] = actual_consumer
+            else:
+                self.config[group] = {stream: actual_consumer}
+
+        return decorator

--- a/telstar/consumer.py
+++ b/telstar/consumer.py
@@ -146,9 +146,9 @@ class MultiConsumer(object):
     def run(self):
         log.info(f"Starting consumer loop for Group {self.group_name}")
         while True:
-            self._once()
+            self.run_once()
 
-    def _once(self):
+    def run_once(self):
         self.transfer_and_process_stream_history(self.streams)
         # With our history processes we can now start waiting for new message to arrive `>`
         config = {k: ">" for k in self.streams}

--- a/telstar/consumer.py
+++ b/telstar/consumer.py
@@ -217,7 +217,8 @@ class MultiConsumer(object):
 
         if not result:
             return 0
-
+        # Sort the message afterwards in order to restore the order they where sent in, this can only be a best effort
+        # approach and does not guarantee the correct order when using `xreadgroup` with multiple streams.
         for processed, t in enumerate(sorted(result, key=lambda t: t[1]), start=1):
             self.work(*t)
         return processed

--- a/test_telstar.py
+++ b/test_telstar.py
@@ -69,7 +69,7 @@ def test_consumer_run(link: redis.Redis):
     ]]
     c = Consumer(link, "mygroup", "myname", "mytopic", callback)
     c.transfer_and_process_stream_history = lambda *a, **kw: None
-    c._once()
+    c.run_once()
     callback.assert_called()
 
 
@@ -91,7 +91,7 @@ def test_consumer_run_callback(link: redis.Redis):
     ]]
     c = Consumer(link, "mygroup", "myname", "mytopic", callback)
     c.transfer_and_process_stream_history = lambda *a, **kw: None
-    c._once()
+    c.run_once()
 
     assert called is True
 
@@ -109,7 +109,7 @@ def test_consumer_checkpoint(link: redis.Redis):
         b"telstar:stream:mytopic", [["stream_msg_id", {b'message_id': msg_id, b"data": "{}"}]]
     ]]
     c = Consumer(link, "mygroup", "myname", "mytopic", callback)
-    c._once()
+    c.run_once()
     link.get.assert_any_call("telstar:checkpoint:telstar:stream:mytopic:cg:mygroup:myname")
     pipeline.set.assert_called_with("telstar:checkpoint:telstar:stream:mytopic:cg:mygroup:myname", "stream_msg_id")
 
@@ -135,7 +135,7 @@ def test_consumer_with_multiple_stearms(link):
 
     mc = MultiConsumer(link, "group", "name", config)
     mc.transfer_and_process_stream_history = lambda *a, **kw: None
-    mc._once()
+    mc.run_once()
 
     assert callback1.call_count == 2
     assert callback2.call_count == 1

--- a/test_telstar.py
+++ b/test_telstar.py
@@ -260,11 +260,11 @@ def test_app_consumer_strictness(realdb, reallink, msg_schema):
 def test_app_consumer_ack_invalid(realdb, reallink, mocker, msg_schema):
     app = telstar.app(reallink, consumer_name="c1")
 
-    @app.consumer("group", "mytopic", schema=msg_schema, acknowledge_invalid=True)
+    @app.consumer("group", "mytopic", schema=msg_schema, acknowledge_invalid=True, strict=False)
     def callback(data: dict):
         pass
 
-    telstar.stage("mytopic", dict(name="1", email="invalid"))
+    telstar.stage("mytopic", dict(name="1", email="a@b.com"))
     StagedProducer(reallink, realdb).run_once()
 
     ack = mocker.spy(MultiConsumer, "acknowledge")
@@ -277,7 +277,7 @@ def test_app_consumer_do_not_ack_invalid(realdb, reallink, mocker, msg_schema):
     app = telstar.app(reallink, consumer_name="c1")
     m = mock.Mock()
 
-    @app.consumer("group", "mytopic", schema=msg_schema, acknowledge_invalid=False)
+    @app.consumer("group", "mytopic", schema=msg_schema, acknowledge_invalid=False, strict=False)
     def callback(data: dict):
         m()
 

--- a/test_telstar.py
+++ b/test_telstar.py
@@ -230,15 +230,16 @@ def test_app_pattern(realdb, reallink, msg_schema):
     app = telstar.app(reallink, consumer_name="c1")
     m = mock.Mock()
 
-    @app.consumer("group", "mytopic", schema=msg_schema)
+    @app.consumer("group", ["mytopic", "mytopic2"], schema=msg_schema)
     def callback(data: dict):
         m()
 
     telstar.stage("mytopic", dict(name="1", email="a@b.com"))
+    telstar.stage("mytopic2", dict(name="1", email="a@b.com"))
     StagedProducer(reallink, realdb).run_once()
 
     app.run_once()
-    m.assert_called_once()
+    assert m.call_count == 2
 
 
 @pytest.mark.integration

--- a/test_telstar.py
+++ b/test_telstar.py
@@ -236,10 +236,11 @@ def test_consumer_once(realdb, reallink):
     assert m.run() == 10  # Successfully proccessed 10 message but only five got ack'ed
 
     m.stop = 10
-    assert m.run() == 5
-    assert m.run() == 0
+    assert m.run() == 5  # Processes the remaining five
+    assert m.run() == 0  # Nothing to process anylonger
 
     assert result == list(range(10))
+
 
 @pytest.mark.integration
 def test_consume_order(realdb, reallink):
@@ -272,4 +273,4 @@ def test_consume_order(realdb, reallink):
         return sum([x + 1 == y for x, y in zip(l, l[1:])])
 
     # Maximum monotony
-    assert monotonicity(result) == 11
+    assert monotonicity(result) >= 4

--- a/test_telstar.py
+++ b/test_telstar.py
@@ -347,4 +347,4 @@ def test_consume_order(realdb, reallink):
         return sum([x + 1 == y for x, y in zip(l, l[1:])])
 
     # Maximum monotony
-    assert monotonicity(result) >= 4
+    assert monotonicity(result) >= 3


### PR DESCRIPTION
This PR includes:
- a new way to write consumers as shown in the example
- more strictness in the `ThreadedMultiConsumer` which now fails if any of the threads fail
- message schema validation through https://marshmallow.readthedocs.io/en/3.0/index.html
- use a pipeline to add messages in batches in the `StagedProducer` - weakening the best effort ordering

```python
app = telstar.app(reallink, consumer_name="c1")

class MyObjSchema(Schema):
    name = fields.Str()
    email = fields.Email()

# `strict` raises an exception if the schema does not validate
# `acknowledge_invalid` ack a message even if does not validate
@app.consumer("group", "mytopic", schema=MyObjSchema, strict=True, acknowledge_invalid=True)
def callback(data: dict):
    print(data)

@app.consumer("group.v2", "mytopic", schema=MyObjSchema, strict=True, acknowledge_invalid=True)
def callback(msg: Message):
    # Through annotations you can request access to the 
    # entire message - e.g. `msg.data`, `msg.msg_id` and `msg.stream_name`
    print(msg)


if __name__ == "__main__":
    app.run()
```