### PR TITLE
Add admin interface

### DIFF
--- a/telstar/__init__.py
+++ b/telstar/__init__.py
@@ -1,7 +1,7 @@
 """
 Telstar is a package to write producer and consumers groups against redis streams.
 """
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 import inspect
 import logging

--- a/telstar/__init__.py
+++ b/telstar/__init__.py
@@ -12,9 +12,12 @@ from marshmallow import Schema, ValidationError
 
 from .com import Message, StagedMessage
 from .consumer import MultiConsumer, ThreadedMultiConsumer
+from .admin import admin
 
 logging.getLogger(__package__).addHandler(logging.NullHandler())
 log = logging.getLogger(__package__)
+
+admin = admin
 
 
 def stage(topic, data):

--- a/telstar/__init__.py
+++ b/telstar/__init__.py
@@ -62,7 +62,7 @@ class app:
                         fn(msg) if fullmessage else fn(msg.data)
                         done()
                     except ValidationError as err:
-                        log.error("Unable to validate message", exc_info=True)
+                        log.error(f"Unable to validate message: {msg}", exc_info=True)
                         if acknowledge_invalid:
                             done()
                         if strict:

--- a/telstar/admin.py
+++ b/telstar/admin.py
@@ -1,0 +1,57 @@
+import redis
+from .com import Message
+
+
+class AdminMessage:
+    def __init__(self, message: Message):
+        self.message: Message = message
+
+    def mark_as_seen(self):
+        pass
+
+    def ack(self):
+        pass
+
+    def remove(self):
+        pass
+
+
+class Consumer:
+    def remove(self):
+        pass
+
+
+class Stream:
+    def trim(self, size):
+        pass
+
+    def get_pending_message(self):
+        pass
+
+
+class Group:
+    def remove(self):
+        pass
+
+
+class admin:
+    def __init__(self, link: redis.Redis):
+        self.link: redis.Redis = link
+
+    def get_streams(self):
+        pass
+
+    def get_consumers(self):
+        pass
+
+    def get_groups(self):
+        pass
+
+    def get_dead_groups(self):
+        pass
+
+    def get_dead_consumers(self):
+        pass
+
+    def get_broken_messages(self):
+        pass

--- a/telstar/admin.py
+++ b/telstar/admin.py
@@ -9,15 +9,6 @@ class AdminMessage:
         self.time_since_delivered = time_since_delivered
         self.times_delivered = times_delivered
 
-    def mark_as_seen(self):
-        pass
-
-    def ack(self):
-        pass
-
-    def remove(self):
-        pass
-
 
 class Consumer:
     def __init__(self, name: bytes, pending: int, idle: int):
@@ -55,9 +46,6 @@ class Group:
     def get_consumers(self):
         return [Consumer(**info) for info in self.link.xinfo_consumers(self.stream_name, self.name)]
 
-    def remove(self):
-        pass
-
 
 class admin:
     def __init__(self, link: redis.Redis):
@@ -70,15 +58,3 @@ class admin:
 
     def get_consumers(self):
         return sum([g.get_consumers() for s in self.get_streams() for g in s.get_groups()], [])
-
-    def get_groups(self):
-        pass
-
-    def get_dead_groups(self):
-        pass
-
-    def get_dead_consumers(self):
-        pass
-
-    def get_broken_messages(self):
-        pass

--- a/telstar/admin.py
+++ b/telstar/admin.py
@@ -1,10 +1,13 @@
 import redis
-from .com import Message
+from functools import reduce
 
 
 class AdminMessage:
-    def __init__(self, message: Message):
-        self.message: Message = message
+    def __init__(self, message_id: bytes, consumer: str, time_since_delivered: int, times_delivered: int):
+        self.message_id = message_id
+        self.consumer = consumer
+        self.time_since_delivered = time_since_delivered
+        self.times_delivered = times_delivered
 
     def mark_as_seen(self):
         pass
@@ -17,19 +20,41 @@ class AdminMessage:
 
 
 class Consumer:
-    def remove(self):
-        pass
+    def __init__(self, name: bytes, pending: int, idle: int):
+        self.name = name
+        self.pending_messages = pending
+        self.idle_time = idle
 
 
 class Stream:
-    def trim(self, size):
-        pass
+    def __init__(self, stream_name, link: redis.Redis):
+        self.stream_name = stream_name
+        self.link = link
 
-    def get_pending_message(self):
-        pass
+    def get_groups(self):
+        return [Group(self.link, name=info["name"], stream_name=self.stream_name, **self.link.xpending(self.stream_name, info["name"]))
+                for info in self.link.xinfo_groups(self.stream_name)]
+
+    def get_pending_messages(self):
+        return sum([g.get_pending_messages() for g in self.get_groups()], [])
 
 
 class Group:
+    def __init__(self, link: redis.Redis, name: str, stream_name: str, pending: int, min, max, consumers):
+        self.link = link
+        self.name = name
+        self.stream_name = stream_name
+        self.pending, self.min, self.max, self.consumers = pending, min, max, consumers
+
+    def get_pending_messages(self):
+        if self.pending == 0:
+            return []
+        return [AdminMessage(**info)
+                for info in self.link.xpending_range(self.stream_name, self.name, self.min, self.max, self.pending)]
+
+    def get_consumers(self):
+        return [Consumer(**info) for info in self.link.xinfo_consumers(self.stream_name, self.name)]
+
     def remove(self):
         pass
 
@@ -38,11 +63,13 @@ class admin:
     def __init__(self, link: redis.Redis):
         self.link: redis.Redis = link
 
-    def get_streams(self):
-        pass
+    def get_streams(self, match=None):
+        match = match or ""
+        streams = self.link.scan_iter(match=f"telstar:stream:{match}*")
+        return [Stream(s, self.link) for s in streams]
 
     def get_consumers(self):
-        pass
+        return sum([g.get_consumers() for s in self.get_streams() for g in s.get_groups()], [])
 
     def get_groups(self):
         pass

--- a/test_telstar.py
+++ b/test_telstar.py
@@ -336,6 +336,11 @@ def test_consumer_once(realdb, reallink):
 
 
 @pytest.mark.integration
+def test_admin(reallink):
+    admin = telstar.admin(reallink)
+
+
+@pytest.mark.integration
 def test_consume_order(realdb, reallink):
     result = list()
     telstar.stage("mytopic", dict(i=1))


### PR DESCRIPTION
This PR introduces a simple object to get information out of the current streams, groups, consumers, and messages - basic usage.

```python
# Assuming there are messages already on the streams. 
[stream] = admin.get_streams()
[msg] = stream.get_pending_messages()
[grp] = stream.get_groups()
[consumer] = grp.get_consumers()

assert msg.times_delivered == 2
assert consumer.idle_time < 1000 # msec

```
- closes #8 