### PR TITLE
Give the user a neater way to deal with errors

### DIFF
--- a/telstar/__init__.py
+++ b/telstar/__init__.py
@@ -40,9 +40,18 @@ class app:
         self.consumer_name: str = consumer_name
         self.consumer_cls: MultiConsumer = consumer_cls
         self.kwargs = kwargs
+        self.error_handlers = {}
+
+    def _register_error_handler(self, exc_class, fn):
+        self.error_handlers[exc_class] = fn
+
+    def errorhandler(self, exc_class):
+        def decorator(fn):
+            self._register_error_handler(exc_class, fn)
+        return decorator
 
     def get_consumer(self) -> MultiConsumer:
-        return self.consumer_cls(self.link, self.consumer_name, self.config, **self.kwargs)
+        return self.consumer_cls(self.link, self.consumer_name, self.config, error_handlers=self.error_handlers, **self.kwargs)
 
     def start(self):
         self.get_consumer().run()

--- a/telstar/__init__.py
+++ b/telstar/__init__.py
@@ -15,7 +15,7 @@ from .admin import admin
 from .com import Message, StagedMessage
 from .consumer import MultiConsumer, ThreadedMultiConsumer
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"
 
 
 logging.getLogger(__package__).addHandler(logging.NullHandler())

--- a/telstar/com/__init__.py
+++ b/telstar/com/__init__.py
@@ -7,6 +7,10 @@ import peewee
 from peewee import ModelSelect
 
 
+class MessageError(Exception):
+    pass
+
+
 class TelstarEncoder(json.JSONEncoder):
     def default(self, o):
         if isinstance(o, datetime):


### PR DESCRIPTION
This allows using the following pattern in telstar to deal with errors

```python
    app = telstar.app(reallink, consumer_name="c1")

    @app.consumer("group", "mytopic", schema=msg_schema, strict=True)
    def callback(data: dict):
        print(data)

    @app.errorhandler(MessageError)
    def handler(exc, ack):
        # Do something with the exception
        ack() # This acknowledges the message allowing the consumer to move past it
```