### PR TITLE
Add feature to delay sending of staged messages

### DIFF
--- a/telstar/__init__.py
+++ b/telstar/__init__.py
@@ -5,7 +5,7 @@ import inspect
 import logging
 from datetime import datetime
 from functools import wraps
-from typing import Callable, Dict, List, Union
+from typing import Callable, Dict, List, Union, Optional
 from uuid import UUID
 
 import redis
@@ -25,8 +25,8 @@ log = logging.getLogger(__package__)
 admin = admin
 
 
-def stage(topic: str, data: Dict[str, Union[int, str, datetime, UUID]]) -> UUID:
-    e = staging.repository.create(topic=topic, data=data)
+def stage(topic: str, data: Dict[str, Union[int, str, datetime, UUID]], delay: Optional[int] = None) -> UUID:
+    e = staging.repository.create(topic=topic, data=data, delay=delay or 0)
     return e.msg_uid
 
 

--- a/test_telstar.py
+++ b/test_telstar.py
@@ -1,5 +1,6 @@
 import os
 import uuid
+import time
 from datetime import datetime
 from unittest import mock
 
@@ -260,12 +261,16 @@ def test_staged_producer_done_callback_removes_staged_events(db, link):
 
 
 def test_staged_producer_delay_sending_message(db, link):
-    telstar.stage("mytopic", dict(a=1), delay=10)
+    telstar.stage("mytopic", dict(a=1), delay=4)
     telstar.stage("mytopic", dict(b=1))
     msgs, cb = StagedProducer(link, db, batch_size=10).get_records()
     assert len(msgs) == 1
-    assert len(telstar.staged()) == 2
+    assert len(telstar.staged()) == 1
     cb()
+    msgs, _ = StagedProducer(link, db).get_records()
+    assert len(msgs) == 0
+    assert len(telstar.staged()) == 0
+    time.sleep(5)
     msgs, _ = StagedProducer(link, db).get_records()
     assert len(msgs) == 1
     assert len(telstar.staged()) == 1

--- a/test_telstar.py
+++ b/test_telstar.py
@@ -259,6 +259,18 @@ def test_staged_producer_done_callback_removes_staged_events(db, link):
     assert len(telstar.staged()) == 1
 
 
+def test_staged_producer_delay_sending_message(db, link):
+    telstar.stage("mytopic", dict(a=1), delay=10)
+    telstar.stage("mytopic", dict(b=1))
+    msgs, cb = StagedProducer(link, db, batch_size=10).get_records()
+    assert len(msgs) == 1
+    assert len(telstar.staged()) == 2
+    cb()
+    msgs, _ = StagedProducer(link, db).get_records()
+    assert len(msgs) == 1
+    assert len(telstar.staged()) == 1
+
+
 def test_consumer_once_keys(link):
     callback = mock.Mock()
     m = MultiConsumeOnce(link, "testgroup", {"mystream": callback})


### PR DESCRIPTION
### Intented usage
There might be cases where you want to delay the sending of messages. 
For instance when scheduling emails into the future. This can now be achieved using a primitive consumer that sends emails in response to incoming messages. 

With this approach, we can deploy the delivery of the message until the email is supposed to be sent. The upside of this is that our consumer still does not need to be stateful. 

What about unscheduling an email, well just keep the message ID and remove it from the staging area. Which also means that the producer has the burden of state.