### PR TITLE
Give up control over transaction.

### DIFF
--- a/telstar/__init__.py
+++ b/telstar/__init__.py
@@ -16,7 +16,7 @@ from .com import Message
 from .config import staging
 from .consumer import MultiConsumer, ThreadedMultiConsumer
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 
 logging.getLogger(__package__).addHandler(logging.NullHandler())

--- a/telstar/com/sqla.py
+++ b/telstar/com/sqla.py
@@ -104,13 +104,7 @@ class _StagedMessageRepository:
             delay = kwargs.pop("delay")
             kwargs["send_at"] = datetime.now() + timedelta(seconds=delay)
         obj = self.model(**kwargs)
-        try:
-            self.db.add(obj)
-            self.db.commit()
-        except Exception as e:
-            if e.orig:
-                raise e.orig  # Surface the type error that might happen when the json is invalid
-            raise e
+        self.db.add(obj)
         return obj
 
     def setup(self, database):
@@ -127,7 +121,6 @@ class _StagedMessageRepository:
     def mark_as_sent(self, messages):
         for m in messages:
             m.sent = True
-        return self.db.commit()
 
 
 StagedMessageRepository = _StagedMessageRepository()


### PR DESCRIPTION
When running a producer in a loop with `autocommit=True` we cannot
`commit` from the repository when using the `context_callable` that
already starts a transaction.

In order to solve this we give up control over the transaction entirely
for sqlalchemy and leave it up to the user to `commit` the changes from
using `telstar.stage` - which would be the case for applications build
with frameworks already managing the transaction for the user.